### PR TITLE
Fix issue with PropTypes being moved to different library

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import { PropTypes } from 'prop-types';
 import {
   View,
   TouchableOpacity,


### PR DESCRIPTION
This is the fix required for #5.

Apologies, I've only just started using React/React-native etc. let me know if there's anything else I need to include, like dependencies etc. I already had prop-types in my node_modules so was able to test it successfully.

Cheers,
Josh