### PR TITLE
fixed useNativeDriver not assigned warning

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -42,6 +42,7 @@ class CircleButton extends Component {
       toValue,
       duration,
       easing: Easing.linear,
+      useNativeDriver: true
     }).start();
   }
 


### PR DESCRIPTION
Dear developer, react native was giving this warning 'useNativeDriver not assigned'. I think, adding this property solves the problem